### PR TITLE
Fix the notification registration

### DIFF
--- a/iOS/samples/GraphNotifications/GraphNotificationsSample/AppDelegate.m
+++ b/iOS/samples/GraphNotifications/GraphNotificationsSample/AppDelegate.m
@@ -29,20 +29,6 @@ void uncaughtExceptionHandler(NSException* uncaughtException)
     }
 }
 
-
-
-- (void)createNotificationRegistrationWithToken:(NSString* _Nonnull)deviceToken
-{
-    _notificationRegistration = [[MCDConnectedDevicesNotificationRegistration alloc] init];
-    _notificationRegistration.type = MCDNotificationTypeAPN;
-    _notificationRegistration.appId = [[NSBundle mainBundle] bundleIdentifier];
-    _notificationRegistration.appDisplayName = (NSString*)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-    _notificationRegistration.token = deviceToken;
-    NSLog(@"GraphNotifications Successfully created notification registration!");
-    NSLog(@"platformManager info %@", _platformManager);
-    [_platformManager setNotificationRegistration: _notificationRegistration];
-}
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     NSSetUncaughtExceptionHandler(&uncaughtExceptionHandler);
@@ -146,7 +132,7 @@ didRegisterUserNotificationSettings:(__unused UIUserNotificationSettings*)notifi
 
     @try
     {
-        [self createNotificationRegistrationWithToken:deviceTokenStr];
+        [_platformManager setNotificationRegistration: deviceTokenStr];
     }
     @catch (NSException* exception)
     {

--- a/iOS/samples/GraphNotifications/GraphNotificationsSample/ConnectedDevicesPlatformManager.h
+++ b/iOS/samples/GraphNotifications/GraphNotificationsSample/ConnectedDevicesPlatformManager.h
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, AccountRegistrationState) {
 - (AnyPromise*)signInMsaAsync;
 - (AnyPromise*)signOutAsync:(Account*)account;
 - (NSMutableArray<Account*>*)deserializeAccounts;
-- (void)setNotificationRegistration:(MCDConnectedDevicesNotificationRegistration*)registration;
+- (void)setNotificationRegistration:(NSString*)deviceToken;
 @end
 
 #endif /* ConnectedDevicesPlatformManager_h */

--- a/iOS/samples/GraphNotifications/GraphNotificationsSample/ConnectedDevicesPlatformManager.m
+++ b/iOS/samples/GraphNotifications/GraphNotificationsSample/ConnectedDevicesPlatformManager.m
@@ -444,22 +444,23 @@
     });
 }
 
-- (void)setNotificationRegistration:(NSString*)tokenString {
+- (void)setNotificationRegistration:(NSString*)deviceToken {
+    MCDConnectedDevicesNotificationRegistration* notificationRegistration = [[MCDConnectedDevicesNotificationRegistration alloc] init];
+    notificationRegistration.type = MCDNotificationTypeAPN;
+    notificationRegistration.appId = [[NSBundle mainBundle] bundleIdentifier];
+    notificationRegistration.appDisplayName = (NSString*)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    notificationRegistration.token = deviceToken;
     
-    MCDConnectedDevicesNotificationRegistration* registration = [MCDConnectedDevicesNotificationRegistration new];
+    NSLog(@"GraphNotifications Successfully created notification registration!");
     
     if ([[UIApplication sharedApplication] isRegisteredForRemoteNotifications])
     {
-        registration.type = MCDNotificationTypeAPN;
+        notificationRegistration.type = MCDNotificationTypeAPN;
     }
     else
     {
-        registration.type = MCDNotificationTypePolling;
+        notificationRegistration.type = MCDNotificationTypePolling;
     }
-    
-    registration.appId = [[NSBundle mainBundle] bundleIdentifier];
-    registration.appDisplayName = (NSString*)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-    registration.token = tokenString;
     
     // The two cases of receiving a new notification token are:
     // 1. A notification registration is asked for and now it is available. In this case there is a pending promise that was made
@@ -468,8 +469,7 @@
     //
     // In order to most cleany handle both cases set the new notification information and then trigger a re registration of all accounts
     // that are in good standing.
-    [self.apnsManager setNotificationRegistration:registration accounts:self.accounts];
+    [self.apnsManager setNotificationRegistration:notificationRegistration accounts:self.accounts];
 }
-
 
 @end


### PR DESCRIPTION
Previously, the method declared on `ConnectedDevicesPlatformManager.h` was not the same as `ConnectedDevicesPlatformManager.m`:
- `- (void)setNotificationRegistration:(MCDConnectedDevicesNotificationRegistration*)registration;` vs `- (void)setNotificationRegistration:(NSString*)tokenString`

So I've changed to get the device token (string) on `.m` and create the `MCDConnectedDevicesNotificationRegistration` inside him.